### PR TITLE
Add dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,20 @@ Clone the repo, install dependencies using yarn (or npm) and run the server:
 yarn
 yarn start
 ```
+or
+```bash
+npm install
+npm start
+```
 
-To run and watch HTML:
+You can also run the app in development mode which automatically loads your changes to JS files and templates:
 
 ```bash
-# note the -e which means we watch for changes in templates too
-nodemon -e "js html" index.js
+yarn dev
+```
+or
+```bash
+npm run dev
 ```
 
 ## Set up your own backend

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "start": "node index.js",
+    "dev": "nodemon -e 'js html' index.js",
     "test": "nyc ava",
     "test:watch": "nyc ava --watch",
     "test:report": "nyc ava && nyc report --reporter=text-lcov | coveralls"


### PR DESCRIPTION
This PR adds a command to run the app in development with:

```
npm run dev
```
or 
```
yarn dev
```

I also documented it in the README. 

Addresses #46 although not fully since it doesn't update the guide. 