### PR TITLE
[s]: display exception raised when loading theme

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -248,7 +248,7 @@ module.exports.loadTheme = function (app) {
     loadExtension(theme, themePath, 'theme')(app)
   } catch (e) {
     const theme = config.get('THEME')
-    console.warn(`WARNING: Failed to load theme -- ${theme}`)
+    console.warn('WARNING: Failed to load theme', theme, e)
   }
 }
 


### PR DESCRIPTION
Found that while working on a theme: error stack trace was not displayed.

I reproduced the way plugin errors are displayed

https://github.com/datopian/frontend-v2/blob/dcbafc57e29980d36ee8047baf06e9239543e445/utils/index.js#L274

Before:

```
Loading configured theme...                                                                                                                   
ckan-ng-theme-xxx                                                                                                                           
WARNING: Failed to load theme -- ckan-ng-theme-xxx                                                                                          
Loading configured plugins...                                                                                                                 
Listening on :4000                                                                                                                            
```

After:

```
Loading configured theme...                                                                                                                   
ckan-ng-theme-xxx                                                                                                                          
Loading configured plugins...                                                                                                                 
Listening on :4000                                                                                                                            
(node:8540) UnhandledPromiseRejectionWarning: ReferenceError: utils is not defined                                                            
    at app.get (/home/cbenz/Dev/datopian/frontend-v2/themes/ckan-ng-theme-xxx/index.js:54:22)                                               
    at process._tickCallback (internal/process/next_tick.js:68:7)                                                                             
(node:8540) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async functio
n without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)                                     
(node:8540) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled 
will terminate the Node.js process with a non-zero exit code.                                                                                 
```