### PR TITLE
[s]: wrap Model.getProfile in a try/catch block

### DIFF
--- a/routes/dms.js
+++ b/routes/dms.js
@@ -152,19 +152,24 @@ module.exports = function () {
       datapackage.views.push(view)
     })
 
-    const profile = await Model.getProfile(req.params.owner)
-    res.render('showcase.html', {
-      title: req.params.owner + ' | ' + req.params.name,
-      dataset: datapackage,
-      owner: {
-        name: profile.name,
-        title: profile.title,
-        description: utils.processMarkdown.render(profile.description),
-        avatar: profile.image_display_url || profile.image_url
-      },
-      thisPageFullUrl: req.protocol + '://' + req.get('host') + req.originalUrl,
-      dpId: JSON.stringify(datapackage).replace(/'/g, "&#x27;") // replace single quotes
-    })
+    try {
+      const profile = await Model.getProfile(req.params.owner)
+      res.render('showcase.html', {
+        title: req.params.owner + ' | ' + req.params.name,
+        dataset: datapackage,
+        owner: {
+          name: profile.name,
+          title: profile.title,
+          description: utils.processMarkdown.render(profile.description),
+          avatar: profile.image_display_url || profile.image_url
+        },
+        thisPageFullUrl: req.protocol + '://' + req.get('host') + req.originalUrl,
+        dpId: JSON.stringify(datapackage).replace(/'/g, "&#x27;") // replace single quotes
+      })
+    } catch (err) {
+      next(err)
+      return
+    }
   })
 
   router.get('/:owner/:name/datapackage.json', async (req, res, next) => {


### PR DESCRIPTION
Without this, opening an URL with a wrong owner like http://localhost:4000/foo/lidar-aerien-2015 instead of http://localhost:4000/ville-de-montreal/lidar-aerien-2015 loads indefinetly:

```
(node:1549) UnhandledPromiseRejectionWarning: #<Response>                                                                                     
(node:1549) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async functio
n without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)                                     
```

I reproduced the same pattern which can be found each time there is a call to an `async function`.

Now the `404 error` is displayed.