### PR TITLE
Configurable WP blog path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,7 @@ You can use one of built-in CMS plugins - check it out below.
 
 #### Wordpress
 
-The wordpress plugin (`/plugins/wp`) ships with frontend-v2. To enable it via `.env` file:
-
-```
-PLUGINS=wp
-```
-
-Use `WP_URL` environment variable to point to your WordPress instance. For example, we have test wordpress blog here https://edscms.home.blog/ so it would be:
-
-```
-WP_URL=https://edscms.home.blog/
-```
-
-If your blog is private, you can set up `WP_TOKEN` environment variable to pass your access token. To get access token for private WP blog, check out this - https://developer.wordpress.com/docs/oauth2/.
+Read about WordPress plugin here: https://github.com/datopian/frontend-v2/blob/master/plugins/wp/README.md
 
 #### CKAN Pages
 

--- a/config/index.js
+++ b/config/index.js
@@ -20,6 +20,7 @@ nconf.defaults({
   API_URL: api_url,
   SITE_URL: process.env.SITE_URL || 'http://0.0.0.0:4000',
   WP_URL: process.env.WP_URL || 'http://127.0.0.1:6000',
+  WP_BLOG_PATH: process.env.WP_BLOG_PATH || '/news',
   WP_TOKEN: process.env.WP_TOKEN || '',
   THEME_DIR: process.env.THEME_DIR || 'themes',
   NODE_MODULES_PATH: process.env.NODE_MODULES_PATH || 'node_modules',

--- a/env.template
+++ b/env.template
@@ -1,10 +1,11 @@
 PLUGINS="example wp"
-WP_TOKEN=
 NODE_ENV=development
 THEME=example
 TRANSLATIONS=
 API_URL=http://127.0.0.1:5000/api/3/action/
 WP_URL=http://127.0.0.1:6000
+WP_BLOG_PATH=
+WP_TOKEN=
 
 GA_ID=
 CKAN_PAGES_URL=

--- a/plugins/wp/README.md
+++ b/plugins/wp/README.md
@@ -1,0 +1,19 @@
+The wordpress plugin (`/plugins/wp`) ships with frontend-v2. To enable it via `.env` file:
+
+```
+PLUGINS=wp
+```
+
+Use `WP_URL` environment variable to point to your WordPress instance. For example, we have test wordpress blog here https://oddk.home.blog/ so it would be:
+
+```
+WP_URL=https://oddk.home.blog/
+```
+
+Use `WP_BLOG_PATH` environment variable to configure where your blog should be located in your site - by default, it is at `/news`. To change it, e.g., to `/blog`:
+
+```
+WP_BLOG_PATH="/blog"
+```
+
+If your blog is private, you can set up `WP_TOKEN` environment variable to pass your access token. To get access token for private WP blog, check out this - https://developer.wordpress.com/docs/oauth2/.

--- a/plugins/wp/index.js
+++ b/plugins/wp/index.js
@@ -4,10 +4,12 @@ const express = require('express')
 const moment = require('moment')
 
 const cms = require('./cms')
+const config = require('../../config')
 
 
 module.exports = function (app) {
   const Model = new cms.CmsModel()
+  const blogPath = config.get('WP_BLOG_PATH')
 
   app.get('/', async (req, res) => {
     // Get latest 3 blog posts and pass it to home template
@@ -29,8 +31,8 @@ module.exports = function (app) {
     })
   })
 
-  app.get('/news', listStaticPages)
-  app.get('/news/:page', showPostPage)
+  app.get(blogPath, listStaticPages)
+  app.get(`${blogPath}/:page`, showPostPage)
   app.get(['/:page', '/:parent/:page'], showStaticPage)
 
   async function listStaticPages(req, res) {


### PR DESCRIPTION
By default, your blog is at `/news` but you now able to change it via env var:

```
export WP_BLOG_PATH=/blog
```

and now your blog is at `/blog`.

I'm implementing this as it is required for OpenDataDK project and overriding CMS path in the theme doesn't look a great idea.