### PR TITLE
[s]: fix typo

### DIFF
--- a/fixtures/index.js
+++ b/fixtures/index.js
@@ -1,4 +1,4 @@
-'use string'
+'use strict'
 const nock = require('nock')
 
 


### PR DESCRIPTION
I guess this needs no explanation, but in JS it's `use strict`, not `use string` :-)