### PR TITLE
Add env variables for express session

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -27,6 +27,8 @@ nconf.defaults({
   NODE_MODULES_PATH: process.env.NODE_MODULES_PATH || 'node_modules',
   PLUGINS: process.env.FE_PLUGINS || '',
   PLUGIN_DIR: process.env.PLUGIN_DIR || 'plugins',
+  SESSION_COOKIE_MAX_AGE: process.env.SESSION_COOKIE_MAX_AGE,
+  SESSION_SECRET: process.env.SESSION_SECRET || 'keyboard cat',
   // CKAN pages PLUGIN
   CKAN_PAGES_URL: process.env.CKAN_PAGES_URL || api_url,
   // dashboard and maps PLUGIN

--- a/env.template
+++ b/env.template
@@ -7,6 +7,11 @@ WP_URL=http://127.0.0.1:6000
 WP_BLOG_PATH=
 WP_TOKEN=
 
+# Change that in production!
+SESSION_SECRET="keyboard cat"
+# In milliseconds. Session never expires if not set.
+SESSION_COOKIE_MAX_AGE=""
+
 GA_ID=
 CKAN_PAGES_URL=
 GIT_BASE_URL=

--- a/index.js
+++ b/index.js
@@ -48,7 +48,12 @@ module.exports.makeApp = function () {
   app.use(cors())
   app.use(cookieParser())
   app.use(i18n.init)
-  app.use(session({ secret: 'keyboard cat', cookie: { maxAge: 60000 }}))
+  app.use(session({
+    secret: config.get('SESSION_SECRET'),
+    cookie: {
+      maxAge: config.get("SESSION_COOKIE_MAX_AGE")
+    }
+  }))
   app.use(flash())
   
   loadTheme(app)


### PR DESCRIPTION
Fixes #67 

I added new env variables, added them to the configuration and used them in express middleware.

Now the cookie is set to expire with the browser session by default:

![image](https://user-images.githubusercontent.com/12686/64110552-c9682900-cd82-11e9-9ed8-bd42c7220324.png)
