### PR TITLE
Add option to provide `fq` and `facet.field` for search

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -130,6 +130,7 @@ module.exports.convertToStandardCollection = (descriptor) => {
 module.exports.convertToCkanSearchQuery = (query) => {
   const ckanQuery = {
     q: '',
+    fq: '',
     rows: '',
     start: '',
     sort: '',
@@ -139,6 +140,7 @@ module.exports.convertToCkanSearchQuery = (query) => {
   }
 
   ckanQuery.q = query.q
+  ckanQuery.fq = query.fq
 
   // standard 'size' => ckan 'rows'
   ckanQuery.rows = query.size || ''
@@ -166,6 +168,7 @@ module.exports.convertToCkanSearchQuery = (query) => {
   ckanQuery['facet.field'] = query['facet.field'] || ckanQuery['facet.field']
   ckanQuery['facet.limit'] = query['facet.limit'] || ckanQuery['facet.limit']
   ckanQuery['facet.mincount'] = query['facet.mincount'] || ckanQuery['facet.mincount']
+  ckanQuery['facet.field'] = query['facet.field'] || ckanQuery['facet.field']
 
   // Remove attributes with empty string, null or undefined values
   Object.keys(ckanQuery).forEach((key) => (!ckanQuery[key]) && delete ckanQuery[key])


### PR DESCRIPTION
Besides default values, this introduces the possibility to manually provide more custom search params for Solr:

- `fq` for custom generated raw filter queries
- `facet.field` for when more (or fewer) facet fields need to be present in the query

Examples (from a real project):
- `fq` filtering for datasets belonging to multiple groups, e.g. `groups:"k-12" groups:"student-loans"`
- `facet.field` for including a project specific facet, e.g. `['organization', 'groups', 'tags', 'res_format', 'license_id', 'level_of_data_string']`