### PR TITLE
Expose 'lib' and 'utils' to themes and plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ const {loadTheme, loadPlugins} = require('./utils')
 module.exports.makeApp = function () {
   const app = express()
   app.set('config', config)
+  app.set('dms', require('./lib/dms'))
+  app.set('utils', require('./utils/index'))
   app.set('port', config.get('app:port'))
   if (config.get('env') === 'development') {
     const mocks = require('./fixtures')


### PR DESCRIPTION
E.g., I'm developing a theme and I want to use `lib/dms.js` and `utils/index.js` modules. So in my theme `my-theme/index.js` I can do:

```javascript
module.exports = function (app) {
  const dms = app.get('dms')
  const config = app.get('config')
  const utils = app.get('utils')

 // Then I can use these to do my dev work
}
```