### PR TITLE
Readmore link of organizations - opendk fixed

### DIFF
--- a/themes/opendk/views/showcase.html
+++ b/themes/opendk/views/showcase.html
@@ -101,7 +101,7 @@
       <a class="px-4 text-primary text-xl font-semibold" href="/{{ owner.name }}">{{ owner.title }}</a>
 
       <p class="px-4 py-2 text-sm">
-        {{ owner.description | safe | truncate(200) }} <a href="/{{ owner.name }}" class="text-primary font-bold">Læs mere</a>
+        {{ owner.description | safe | truncate(200) | replace("<a", "")  }} <a href="/{{ owner.name }}" class="text-primary font-bold">Læs mere</a>
       </p>
 
       <!-- share links -->


### PR DESCRIPTION
The template variable `owner.description ` contain HTML <a> tags and not closed on truncate. So, can't render plain text cuz it contain other tags also. So, for now it is fixed by simply replacing a tag with nothing 