### PR TITLE
[fix][s]: Fix api url trailing slash

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -8,7 +8,7 @@ nconf.argv()
 
 nconf.use('memory')
 
-const api_url = process.env.API_URL || 'http://127.0.0.1:5000/api/3/action/'
+const api_url = (process.env.API_URL || 'http://127.0.0.1:5000/api/3/action/').replace(/\/?$/, '/')
 
 // This is the object that you want to override in your own local config
 nconf.defaults({

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ module.exports.makeApp = function () {
       return processMarkdown.render(str)
     } catch (e) {
       console.warn('Failed to format markdown', e)
+      return str
     }
   })
   


### PR DESCRIPTION
* Ensure trailing slash for API Url
* If markdown render fails, return original string