### PR TITLE
[fix][xs] fixes dates on front page blogposts

### DIFF
--- a/themes/opendk/views/home.html
+++ b/themes/opendk/views/home.html
@@ -85,7 +85,7 @@ Welcome - Home
             {% endfor %}
           </ul>
         </div>
-        <time class="article-preview_date">{{ post.modified }}</time>
+        <time class="article-preview_date">{{ post.published }}</time>
         <p class="article-preview_content">
           {{post.content | striptags | safe | truncate(200)}}
         </p>


### PR DESCRIPTION
Resolves: 
Dates on blogposts on front page should be the same as on the blog page (showing the release date, not the last edited date).