### PR TITLE
[fix][s] categories in blog page

### DIFF
--- a/themes/opendk/views/blog.html
+++ b/themes/opendk/views/blog.html
@@ -39,8 +39,10 @@
         <div class="mb-3">
           <ul>
             {% for category in post.categories %}
-            <li class="inline px-3 py-1 text-xs text-white rounded mr-3 mb-3 bg-secondary" title="category">
-              {{ category }}
+            <li>
+              <a href="/blog?category={{category}}" class="inline px-3 py-1 text-xs text-white rounded mr-3 mb-3 bg-secondary" title="category">
+                {{ category }}
+              </a>
             </li>
             {% endfor %}
           </ul>
@@ -106,8 +108,8 @@
     <div class="mb-4">
       {% for category in categories %}
       <a class="mb-2 text-center block px-3 py-2 hover:text-white hover:bg-secondary border {{ 'border-primary text-primary' if selectedCategory == category.slug else 'border-secondary' }}"
-        href="/blog?category={{category.slug}}" aria-label="{{__(category.name)}}">
-        <span class="">{{__(category.name)}}</span>
+        href="/blog?category={{category.slug}}" aria-label="{{category.name}}">
+        <span class="">{{category.name}}</span>
       </a>
       {% endfor %}
     </div>

--- a/themes/opendk/views/home.html
+++ b/themes/opendk/views/home.html
@@ -79,8 +79,10 @@ Welcome - Home
         <div class="mb-3">
           <ul>
             {% for category in post.categories %}
-              <li class="inline px-3 py-1 text-xs text-white rounded mr-3 mb-3 bg-secondary" title="category">
-                {{ category }}
+              <li>
+                <a href="/blog?category={{category}}" class="inline px-3 py-1 text-xs text-white rounded mr-3 mb-3 bg-secondary" title="category">
+                  {{ category }}
+                </a>
               </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
Fixes 
```
Why is Events translated to Begivenheder in the category filter?
Could the category label be a linkt to the category eg, "Events" links to blog?category=events
```
from https://gitlab.com/datopian/ckan-next-gen/issues/121#final-round