### PR TITLE
[wp][s] fixes getting wp page with parent

### DIFF
--- a/plugins/wp/cms.js
+++ b/plugins/wp/cms.js
@@ -11,15 +11,34 @@ class CmsModel {
   }
 
 
-  getPost(slug) {
-    return new Promise((resolve, reject) => {
-      this.blog.post({slug: slug}).getBySlug((err, data) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(data)
+  async getPost(slug, parentSlug = "") {
+
+    return new Promise(async (resolve, reject) => {
+
+      // type any will request both pages and posts
+      let query = {type: 'any'}
+
+      if (parentSlug) {
+        try {
+          let parent = await (await this.blog.post({slug: parentSlug})).getBySlug()
+          query.parent_id = parent.ID
+          let posts = (await this.blog.postsList(query)).posts
+          let post = posts.find(post => post.slug == slug)
+          resolve(post)
+        } catch (e) {
+          reject(e)
         }
-      })
+
+      } else {
+        query.slug = slug
+        this.blog.post(query).getBySlug((err, data) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(data)
+          }
+        })
+      }
     })
   }
 

--- a/plugins/wp/index.js
+++ b/plugins/wp/index.js
@@ -108,7 +108,7 @@ module.exports = function (app) {
       slug += `-${locale}`
     }
     try {
-      const post = await Model.getPost(slug)
+      const post = await Model.getPost(req.params.page, req.params.parent)
       res.render('static.html', {
         slug: post.slug,
         parentSlug: req.params.parent,


### PR DESCRIPTION
Using 2 separate requests if there is a parent, because WP API does not allow for a single one:

If to use [`posts/slug:%24post_slug/` method]( https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/slug:%24post_slug/) - we cannot specify parent id - only slug -> if we have two pages one with parent and another without the parent with the same slug - the one without the parent will be returned.

If to use [`posts/` method](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/) we cannot specify slug (they say in the documentation that it can be specified in tag or category, but that does not work in practice)