### PR TITLE
[WIP] [search][s]: Remove duplicate facet items from UI

### DIFF
--- a/routes/dms.js
+++ b/routes/dms.js
@@ -96,23 +96,24 @@ module.exports = function () {
       const result = await Model.search(req.query)
       
       // Prevent duplication of applied facets
-      const q = req.query.q || ""
-      const appliedFacets = q
+      const q = req.query.q
+      const appliedFacets = q && q
         .split(' ')
         .map(pair => pair.split(':'))
         .reduce((acc, cur) => {
-          const [key, val] = cur;
-          acc[key] = acc[key] || [];
-          acc[key].push(val);
-          return acc;
-        }, {});
+          const [key, val] = cur
+          acc[key] = acc[key] || []
+          acc[key].push(val)
+          return acc
+        }, {})
 
-      Object.keys(appliedFacets).forEach(facet => {
-        appliedFacets[facet].forEach(name => {
-          console.log(appliedFacets[facet], facet, name)
-          result.search_facets[facet].items = result.search_facets[facet].items.filter(item => item.name !== name)
+      if (appliedFacets) {
+        Object.keys(appliedFacets).forEach(facet => {
+          appliedFacets[facet].forEach(name => {
+            result.search_facets[facet].items = result.search_facets[facet].items.filter(item => item.name !== name)
+          })
         })
-      })
+      }
 
       // Pagination
       const from = req.query.from || 0

--- a/routes/dms.js
+++ b/routes/dms.js
@@ -94,6 +94,26 @@ module.exports = function () {
   router.get('/search', async (req, res, next) => {
     try {
       const result = await Model.search(req.query)
+      
+      // Prevent duplication of applied facets
+      const q = req.query.q || ""
+      const appliedFacets = q
+        .split(' ')
+        .map(pair => pair.split(':'))
+        .reduce((acc, cur) => {
+          const [key, val] = cur;
+          acc[key] = acc[key] || [];
+          acc[key].push(val);
+          return acc;
+        }, {});
+
+      Object.keys(appliedFacets).forEach(facet => {
+        appliedFacets[facet].forEach(name => {
+          console.log(appliedFacets[facet], facet, name)
+          result.search_facets[facet].items = result.search_facets[facet].items.filter(item => item.name !== name)
+        })
+      })
+
       // Pagination
       const from = req.query.from || 0
       const size = req.query.size || 10


### PR DESCRIPTION
If a facet item is present in a search query -- for example
"tags:wind" -- remove it from the facets UI in search pages.
I think this is better UX and prevents a bug where applying filters
multiple times creates queries like "q?tags:wind tags:wind tags:wind"

Needs tests but please check implementation first