### PR TITLE
Package show get

### DIFF
--- a/lib/dms.js
+++ b/lib/dms.js
@@ -34,13 +34,10 @@ class DmsModel {
   async getPackage(name) {
     const action = 'package_show'
     let url = new URL(resolve(this.api, action))
-    const params = {
-      name_or_id: name
-    }
+    url.search = `name_or_id=${name}`
+    
     let response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(params),
-      headers: { 'Content-Type': 'application/json' }
+      method: 'GET'
     })
     if (response.status !== 200) {
       throw response

--- a/plugins/ckan_pages/cms.js
+++ b/plugins/ckan_pages/cms.js
@@ -37,6 +37,19 @@ class CmsModel {
       throw {statusCode: res.status, message}
     }
   }
+
+  // returns promise
+  async getListOfPages(size) {
+    const url = `${this.api}ckanext_pages_list?page_type=page`
+    const res = await fetch(url)
+    if (res.ok) {
+      const pages = await res.json()
+      return pages.result
+    } else {
+      const message = await res.text()
+      throw {statusCode: res.status, message}
+    }
+  }
 }
 
 module.exports.CmsModel = CmsModel


### PR DESCRIPTION
Use GET instead of POST for package_show

This resolves some unusual behavior from CKAN Cloud / CKAN Classic and seems correspond more closely with the REST philosophy (as per @pwalsh)

Includes an ancillary feature we are using in National-Grid -- ckan pages, getListFfPages