### PR TITLE
[news][s]: news content html tags removed when showing lists

### DIFF
--- a/plugins/ckan_pages/index.js
+++ b/plugins/ckan_pages/index.js
@@ -40,7 +40,7 @@ module.exports = function (app) {
       return {
         slug: post.name,
         title: post.title,
-        content: post.content,
+        content: post.content.replace(/<\/?[^>]+(>|$)/g, ""),
         published: moment(post.date).format('MMMM Do, YYYY'),
         modified: moment(post.modified).format('MMMM Do, YYYY'),
         image: post.featured_image
@@ -56,7 +56,7 @@ module.exports = function (app) {
     try {
       const post = await Model.getPost(slug)
       res.render('post.html', {
-        slug: post.slug,
+        slug: post.name,
         title: post.title,
         content: post.content,
         published: moment(post.date).format('MMMM Do, YYYY'),


### PR DESCRIPTION
Removed html tags when showing truncated content of news, because it opens tags without closing them and creates rendering problems and news.slug doesn't exist.