### PR TITLE
[ckan_pages] getListOfPages - add fixtures + test

### DIFF
--- a/fixtures/index.js
+++ b/fixtures/index.js
@@ -1057,4 +1057,12 @@ module.exports.initMocks = function() {
   nock('http://127.0.0.1:5001', {"encodedQueryParams":true})
     .get('/path/to/data.csv')
     .reply(200, 'a,b,c\n1,2,3');
+  
+  // Mock for ckan_pages getListOfPages
+  nock('http://127.0.0.1:5000', {"encodedQueryParams":true})
+    .persist()
+    .get('/api/3/action/ckanext_pages_list')
+    .query({"page_type": "page"})
+    .reply(200, [{"user_id":"c75d7c1a-3966-44aa-818a-0a5101f3c128","name":"page-one","title":"Page One Title","content":"Page One Content","publish_date":"2019-11-27T00:00:00","page_type":"page","group_id":null},{"user_id":"5e48834c-c835-4f7a-9d1e-f94e6810a721","name":"page-two","title":"Page Two Title","content":"Page Two Content","publish_date":null,"page_type":"page","group_id":null},{"user_id":"5e48834c-c835-4f7a-9d1e-f94e6810a721","name":"page-three","title":"Page Three Title","content":"Page Three Content","publish_date":null,"page_type":"page","group_id":null},{"user_id":"17a6aee1-f442-4928-aad9-a091f87829f9","name":"page-four","title":"Page Four Title","content":"Page Four Content","publish_date":null,"page_type":"page","group_id":null}])
   }
+  

--- a/plugins/ckan_pages/cms.js
+++ b/plugins/ckan_pages/cms.js
@@ -46,6 +46,7 @@ class CmsModel {
       const pages = await res.json()
       return pages
     } else {
+      /*istanbul ignore next*/
       const message = await res.text()
       throw {statusCode: res.status, message}
     }

--- a/plugins/ckan_pages/cms.js
+++ b/plugins/ckan_pages/cms.js
@@ -37,6 +37,19 @@ class CmsModel {
       throw {statusCode: res.status, message}
     }
   }
+  
+  // returns promise
+  async getListOfPages() {
+    const url = `${this.api}ckanext_pages_list?page_type=page`
+    const res = await fetch(url)
+    if (res.ok) {
+      const pages = await res.json()
+      return pages
+    } else {
+      const message = await res.text()
+      throw {statusCode: res.status, message}
+    }
+  }
 }
 
 module.exports.CmsModel = CmsModel

--- a/tests/plugins/ckan_pages.test.js
+++ b/tests/plugins/ckan_pages.test.js
@@ -17,9 +17,10 @@ test('getPost api works for Pages', async t => {
 
 
 test('getListOfPosts api works for Pages', async t => {
-  t.plan(1)
+  const result = await PagesModel.getListOfPages()
 
-  const result = await PagesModel.getListOfPosts()
-
-  t.is(result.length, 3)
+  t.is(result.length, 4)
+  t.is(result[0].title, 'Page One Title')
+  t.is(result[1].name, 'page-two')
+  t.is(result[2].content, 'Page Three Content')
 })


### PR DESCRIPTION
Add `getListOfPages` function to `ckan_pages` module.

Requirement for national grid.

Includes tests.