### PR TITLE
Schema table support

### DIFF
--- a/tests/utils/index.test.js
+++ b/tests/utils/index.test.js
@@ -147,7 +147,8 @@ const datapackage = {
       datastore_active: true,
       id: 'resource-1-id',
       path: 'https://datastore.com/resource-1-id',
-      views: [{name: 'view-1-1'}, {name: 'view-1-2'}]
+      views: [{name: 'view-1-1'}, {name: 'view-1-2'}],
+      fields: "[{\"type\": \"any\", \"name\": \"Field Name\"}]"
     },
     {
       name: 'resource-2',
@@ -185,4 +186,15 @@ test('Prepare data package views', t => {
   const result = utils.prepareViews(datapackage)
   t.is(result.views.length, 3)
   t.deepEqual(result.views[1].resources, ['resource-1'])
+})
+
+
+test('resource.fields => resource.schema', t => {
+  const result = utils.ckanToDataPackage(datapackage)
+  const expectedSchema = {
+    fields: [
+      {name: 'Field Name', type: 'any'}
+    ]
+  }
+  t.deepEqual(result.resources[0].schema, expectedSchema)
 })

--- a/utils/index.js
+++ b/utils/index.js
@@ -100,10 +100,18 @@ module.exports.ckanToDataPackage = function (descriptor) {
       delete resource.url
     }
 
-    if (resource.schema) {
-      const fields = resource.schema
-      resource.schema = {
-        fields
+    if (!resource.schema) {
+      // If 'fields' property exists use it as schema fields
+      if (resource.fields) {
+        if (typeof(resource.fields) === 'string') {
+          try {
+            resource.fields = JSON.parse(resource.fields)
+          } catch (e) {
+            console.log('Could not parse resource.fields')
+          }
+        }
+        resource.schema = {fields: resource.fields}
+        delete resource.fields
       }
     }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -100,8 +100,11 @@ module.exports.ckanToDataPackage = function (descriptor) {
       delete resource.url
     }
 
-    if (!resource.schema) {
-      // TODO: add schema
+    if (resource.schema) {
+      const fields = resource.schema
+      resource.schema = {
+        fields
+      }
     }
 
     return resource


### PR DESCRIPTION
- The schema table supported.
- The schema property can be provided in DMS  using a `scheming` and `composite` extension on CKAN classic. 

```
{
...
revision_id: '392dfb53-17c4-45c3-a236-fc7c3b6ca0b9',
schema: {
    fields: '[{"comment": "School name registered in education department", "description": "This is the school name ", "size": "12", "type": "string", "example": "Datopian School", "unit": "String", "name": "School Name"}]'
  },
url_type: 'upload',
...
}
```