### PR TITLE
[wp][s]: adds original WP API request endpoint

### DIFF
--- a/plugins/wp/cms.js
+++ b/plugins/wp/cms.js
@@ -64,6 +64,10 @@ class CmsModel {
   async getSiteInfo() {
     return await this.blog.get()
   }
+
+  api() {
+    return wpcom.req
+  }
 }
 
 module.exports.CmsModel = CmsModel


### PR DESCRIPTION
Adds the ability to create requests for WP API with this endpoint: https://github.com/Automattic/wpcom.js/blob/master/docs/wpcom.req.md, useful for example for getting [a list of files](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/media/) - as no other endpoint allows to do that (even [media](https://github.com/Automattic/wpcom.js/blob/master/docs/media.md)).