### PR TITLE
Data dictionary fields to table schema

### DIFF
--- a/lib/dms.js
+++ b/lib/dms.js
@@ -42,16 +42,17 @@ class DmsModel {
     }
     response = await response.json()
     const datapackage = utils.ckanToDataPackage(response.result)
-    // Fetch views for the resources
+
     await Promise.all(datapackage.resources.map(async resource => {
-      resource.views = await this.getResourceViews(resource.id)
+      resource = {
+        views: await this.getResourceViews(resource.id), // Fetch views for the resources
+        schema: resource.datastore_active
+          ? await this.getResourceSchema(resource.id) // Get resource schema from datastore data dictionary
+          : undefined,
+        ...resource
+      }
     }))
-    // Get resource schema from datastore data dictionary
-      await Promise.all(datapackage.resources.map(async resource => {
-        if(resource.datastore_active){
-          resource.schema = await this.getResourceSchema(resource.id)
-        }
-      }))
+
     return datapackage
   }
 

--- a/lib/dms.js
+++ b/lib/dms.js
@@ -57,7 +57,7 @@ class DmsModel {
   }
 
   async getResourceSchema(resourceId) {
-    try{
+    try {
       const action = 'datastore_search'
       let url = new URL(resolve(this.api, action))
       let response = await fetch(url, {
@@ -67,8 +67,8 @@ class DmsModel {
         },
         body: JSON.stringify({
           'resource_id' : resourceId,
-          'limit': 0
-       }) 
+          'limit': 0 // as we only need field info, not actual records
+       })
       })
 
       if (response.status !== 200) {

--- a/lib/dms.js
+++ b/lib/dms.js
@@ -43,8 +43,8 @@ class DmsModel {
     response = await response.json()
     const datapackage = utils.ckanToDataPackage(response.result)
 
-    await Promise.all(datapackage.resources.map(async resource => {
-      resource = {
+    datapackage.resources = await Promise.all(datapackage.resources.map(async resource => {
+      return {
         views: await this.getResourceViews(resource.id), // Fetch views for the resources
         schema: resource.datastore_active
           ? await this.getResourceSchema(resource.id) // Get resource schema from datastore data dictionary

--- a/tests/utils/index.test.js
+++ b/tests/utils/index.test.js
@@ -198,3 +198,40 @@ test('resource.fields => resource.schema', t => {
   }
   t.deepEqual(result.resources[0].schema, expectedSchema)
 })
+
+
+test('datastore data dictionary => tableschema', t => {
+  let result = utils.dataStoreDataDictionaryToTableSchema({
+    id: 'column',
+    type: 'text'
+  })
+
+  let expected = {
+    name: 'column',
+    type: 'string'
+  }
+
+  t.deepEqual(result, expected)
+
+  result = utils.dataStoreDataDictionaryToTableSchema({
+    id: 'column',
+    type: 'text',
+    info: {
+      title: 'Column',
+      minLength: 5,
+      maxLength: 10
+    }
+  })
+
+  expected = {
+    name: 'column',
+    type: 'string',
+    title: 'Column',
+    constraints: {
+      minLength: 5,
+      maxLength: 10
+    }
+  }
+
+  t.deepEqual(result, expected)
+})

--- a/utils/index.js
+++ b/utils/index.js
@@ -207,10 +207,15 @@ module.exports.dataStoreDataDictionaryToTableSchema = (dataDictionary) => {
     type: dataDictionaryType2TableSchemaType[dataDictionary.type] || 'any'
   }
   if (dataDictionary.info) {
-    return {
-      ...field,
-      ...dataDictionary.info,
-    }
+    const constraintsAttributes = ['required', 'unique', 'minLength', 'maxLength', 'minimum', 'maximum', 'pattern', 'enum']
+    field.constraints = {}
+    Object.keys(dataDictionary.info).forEach(key => {
+      if (constraintsAttributes.includes(key)) {
+        field.constraints[key] = dataDictionary.info[key]
+      } else {
+        field[key] = dataDictionary.info[key]
+      }
+    })
   }
   return field
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -187,16 +187,31 @@ module.exports.ckanViewToDataPackageView = (ckanView) => {
   return dataPackageView
 }
 
-module.exports.dataStoreDataDictionaryToTableSchema = (ckanSchema) => {
-  let field = {}
-  field.name = ckanSchema.id
-  field.type = ckanSchema.type
-  if (ckanSchema.info) {
+/*
+Takes single field descriptor from datastore data dictionary and coverts into
+tableschema field descriptor.
+*/
+module.exports.dataStoreDataDictionaryToTableSchema = (dataDictionary) => {
+  const dataDictionaryType2TableSchemaType = {
+    'text': 'string',
+    'int': 'integer',
+    'float': 'number',
+    'date': 'date',
+    'time': 'time',
+    'timestamp': 'datetime',
+    'bool': 'boolean',
+    'json': 'object'
+  }
+  const field = {
+    name: dataDictionary.id,
+    type: dataDictionaryType2TableSchemaType[dataDictionary.type] || 'any'
+  }
+  if (dataDictionary.info) {
     return {
       ...field,
-      ...ckanSchema.info,  
+      ...dataDictionary.info,
     }
-  } 
+  }
   return field
 }
 


### PR DESCRIPTION
- fetched dictionary fields information using `dictionary fields` API.
- `ckanSchemaToTableSchema` utils added to convert CKAN dictionary fields to table schema.