### PR TITLE
[fix][xs] Publish date not showing correct values

### DIFF
--- a/plugins/ckan_pages/index.js
+++ b/plugins/ckan_pages/index.js
@@ -18,7 +18,7 @@ module.exports = function (app) {
         slug: post.name,
         title: post.title,
         content: post.content,
-        published: moment(post.date).format('MMMM Do, YYYY'),
+        published: moment(post.publish_date).format('MMMM Do, YYYY'),
         modified: moment(post.modified).format('MMMM Do, YYYY'),
         image: post.featured_image
       }
@@ -41,7 +41,7 @@ module.exports = function (app) {
         slug: post.name,
         title: post.title,
         content: post.content.replace(/<\/?[^>]+(>|$)/g, ""),
-        published: moment(post.date).format('MMMM Do, YYYY'),
+        published: moment(post.publish_date).format('MMMM Do, YYYY'),
         modified: moment(post.modified).format('MMMM Do, YYYY'),
         image: post.featured_image
       }
@@ -59,7 +59,7 @@ module.exports = function (app) {
         slug: post.name,
         title: post.title,
         content: post.content,
-        published: moment(post.date).format('MMMM Do, YYYY'),
+        published: moment(post.publish_date).format('MMMM Do, YYYY'),
         modified: moment(post.modified).format('MMMM Do, YYYY'),
         image: post.featured_image,
         thisPageFullUrl: req.protocol + '://' + req.get('host') + req.originalUrl


### PR DESCRIPTION
@anuveyatsu 

As you can see here:
https://montreal.l3.ckan.io/api/3/action/ckanext_pages_list

or here:
https://montreal.l3.ckan.io/api/3/action/ckanext_pages_show?page=table-de-concertation-premiere-assemblee-pleniere-25-avril-2012

there is no `date` value, but `publish_date` value.

**Before changes**

![montreal_blog_now](https://user-images.githubusercontent.com/12686547/75342370-9cf71a80-5896-11ea-96b7-303fddf7b602.png)

**After changes**

![montreal_news_1](https://user-images.githubusercontent.com/12686547/75342428-b730f880-5896-11ea-98c4-50b726617010.png)
