### PR TITLE
Consistent 'datapackage' object

### DIFF
--- a/routes/dms.js
+++ b/routes/dms.js
@@ -168,7 +168,7 @@ module.exports = function () {
   router.get('/:owner/:name', async (req, res, next) => {
     let datapackage = res.locals.datapackage || null
     try {
-      datapackage = await prepDataPackageForView(req.params.name, datapackage)
+      datapackage = await prepareDataPackageForRender(req.params.name, datapackage)
     } catch (err) {
       /* istanbul ignore next */
       next(err)
@@ -199,7 +199,7 @@ module.exports = function () {
   router.get('/:owner/:name/datapackage.json', async (req, res, next) => {
     let datapackage = res.locals.datapackage || null
     try {
-      datapackage = await prepDataPackageForView(req.params.name, datapackage)
+      datapackage = await prepareDataPackageForRender(req.params.name, datapackage)
     } catch (err) {
       /* istanbul ignore next */
       next(err)
@@ -211,7 +211,7 @@ module.exports = function () {
     res.end(JSON.stringify(datapackage))
   })
 
-  async function prepDataPackageForView(name, datapackage) {
+  async function prepareDataPackageForRender(name, datapackage) {
     if (!datapackage) {
       datapackage = await Model.getPackage(name)
     }

--- a/routes/dms.js
+++ b/routes/dms.js
@@ -167,31 +167,13 @@ module.exports = function () {
 
   router.get('/:owner/:name', async (req, res, next) => {
     let datapackage = res.locals.datapackage || null
-
     try {
-      if (!datapackage) {
-        datapackage = await Model.getPackage(req.params.name)
-      }
+      datapackage = await prepDataPackageForView(req.params.name, datapackage)
     } catch (err) {
       /* istanbul ignore next */
       next(err)
       return
     }
-
-    // Prepare datapackage for display, eg, process markdown, convert values to
-    // human-readable format etc.:
-    datapackage = utils.processDataPackage(datapackage)
-
-    // Prepare resources for display (preview):
-    datapackage = utils.prepareResourcesForDisplay(datapackage)
-
-    // Since "datapackage-views-js" library renders views according to
-    // descriptor's "views" property, we need to generate view objects.
-    // Note that we have "views" per resources so here we will consolidate them.
-    datapackage = utils.prepareViews(datapackage)
-
-    // Data Explorer used a slightly different spec than "datapackage-views-js":
-    datapackage = utils.prepareDataExplorers(datapackage)
 
     try {
       const profile = await Model.getProfile(req.params.owner)
@@ -215,14 +197,23 @@ module.exports = function () {
   })
 
   router.get('/:owner/:name/datapackage.json', async (req, res, next) => {
-    let datapackage = null
-
+    let datapackage = res.locals.datapackage || null
     try {
-      datapackage = await Model.getPackage(req.params.name)
+      datapackage = await prepDataPackageForView(req.params.name, datapackage)
     } catch (err) {
       /* istanbul ignore next */
       next(err)
       return
+    }
+
+    res.setHeader('Content-Type', 'application/json')
+    res.status(200)
+    res.end(JSON.stringify(datapackage))
+  })
+
+  async function prepDataPackageForView(name, datapackage) {
+    if (!datapackage) {
+      datapackage = await Model.getPackage(name)
     }
 
     // Prepare datapackage for display, eg, process markdown, convert values to
@@ -240,10 +231,8 @@ module.exports = function () {
     // Data Explorer used a slightly different spec than "datapackage-views-js":
     datapackage = utils.prepareDataExplorers(datapackage)
 
-    res.setHeader('Content-Type', 'application/json')
-    res.status(200)
-    res.end(JSON.stringify(datapackage))
-  })
+    return datapackage
+  }
 
   router.get('/organization', async (req, res, next) => {
     try {


### PR DESCRIPTION
Created a function that can be re-used/shared so that generated 'datapackage.json' is consistent.

We generate 'datapackage' object for showcase (dataset) page.
We also generate it for 'datapackage.json' api route (`/owner/dataset/datapackage.json`).
Problem is that these 2 objects aren't consistent, however, it should be.
So this PR includes a shared function so that both routes use it and 'datapackage' json is identical.