### PR TITLE
 Sorting query added on datastore search api url

### DIFF
--- a/tests/utils/index.test.js
+++ b/tests/utils/index.test.js
@@ -177,7 +177,7 @@ test('Prepare data package for display', t => {
 test('Prepare resources for display', t => {
   const result = utils.prepareResourcesForDisplay(datapackage)
   t.is(result.displayResources.length, datapackage.resources.length)
-  t.is(result.displayResources[0].api, 'http://127.0.0.1:5000/api/3/action/datastore_search?resource_id=resource-1-id')
+  t.is(result.displayResources[0].api, 'http://127.0.0.1:5000/api/3/action/datastore_search?resource_id=resource-1-id&sort=_id desc')
   t.is(result.displayResources[0].cc_proxy, 'http://127.0.0.1:5000/dataset/dp-id/resource/resource-1-id/proxy')
 })
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -453,7 +453,7 @@ module.exports.prepareResourcesForDisplay = function (datapackage) {
   newDatapackage.displayResources = []
   newDatapackage.resources.forEach((resource, index) => {
     const api = resource.datastore_active
-      ? config.get('API_URL') + 'datastore_search?resource_id=' + resource.id
+      ? config.get('API_URL') + 'datastore_search?resource_id=' + resource.id + '&sort=_id desc'
       : null
     // Use proxy path if datastore/filestore proxies are given:
     let proxy, cc_proxy


### PR DESCRIPTION
By default CKAN `datastore_search` doesn't provide sorted dataset records. so, Adding query `sort=_id desc` on datastore search API  will provide  sorted with _id in descending order. 
 On the table view of data explorer, recently updated data will appear in the first row.