### PR TITLE
Fix/dms try catch

### DIFF
--- a/lib/dms.js
+++ b/lib/dms.js
@@ -11,49 +11,59 @@ class DmsModel {
   }
 
   async search(query, context) {
-    // TODO: context can have API Key so we need to pass it through
-    const action = 'package_search'
-    let url = new URL(resolve(this.api, action))
-    const params = utils.convertToCkanSearchQuery(query)
-    let response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(params),
-      headers: { 'Content-Type': 'application/json' }
-    })
+    try {
+      // TODO: context can have API Key so we need to pass it through
+      const action = 'package_search'
+      let url = new URL(resolve(this.api, action))
+      const params = utils.convertToCkanSearchQuery(query)
+      let response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(params),
+        headers: { 'Content-Type': 'application/json' }
+      })
 
-    response = await response.json()
-    // Convert CKAN descriptor => data package
-    response.result.results = response.result.results.map(pkg => {
-      return utils.ckanToDataPackage(pkg)
-    })
-    return response.result
+      response = await response.json()
+      // Convert CKAN descriptor => data package
+      response.result.results = response.result.results.map(pkg => {
+        return utils.ckanToDataPackage(pkg)
+      })
+      return response.result
+    } catch (e) {
+      console.warn('Error fetching search results', e)
+      return {}
+    }
   }
 
   async getPackage(name) {
-    const action = 'package_show'
-    let url = new URL(resolve(this.api, action))
-    url.search = `id=${name}`
+    try {
+      const action = 'package_show'
+      let url = new URL(resolve(this.api, action))
+      url.search = `id=${name}`
 
-    let response = await fetch(url, {
-      method: 'GET'
-    })
-    if (response.status !== 200) {
-      throw response
-    }
-    response = await response.json()
-    const datapackage = utils.ckanToDataPackage(response.result)
-
-    datapackage.resources = await Promise.all(datapackage.resources.map(async resource => {
-      return {
-        views: await this.getResourceViews(resource.id), // Fetch views for the resources
-        schema: resource.datastore_active && !resource.schema
-          ? await this.getResourceSchema(resource.id) // Get resource schema from datastore data dictionary
-          : undefined,
-        ...resource
+      let response = await fetch(url, {
+        method: 'GET'
+      })
+      if (response.status !== 200) {
+        throw response
       }
-    }))
+      response = await response.json()
+      const datapackage = utils.ckanToDataPackage(response.result)
 
-    return datapackage
+      datapackage.resources = await Promise.all(datapackage.resources.map(async resource => {
+        return {
+          views: await this.getResourceViews(resource.id), // Fetch views for the resources
+          schema: resource.datastore_active && !resource.schema
+            ? await this.getResourceSchema(resource.id) // Get resource schema from datastore data dictionary
+            : undefined,
+          ...resource
+        }
+      }))
+
+      return datapackage
+    } catch (e) {
+      console.warn('Error fetching datapackage', e)
+      return {}
+    }
   }
 
   async getResourceSchema(resourceId) {
@@ -111,26 +121,31 @@ class DmsModel {
   }
 
   async getOrganizations() {
-    const action = 'organization_list'
-    let url = new URL(resolve(this.api, action))
-    const params = {
-      all_fields: true,
-      sort: 'package_count'
+    try {
+      const action = 'organization_list'
+      let url = new URL(resolve(this.api, action))
+      const params = {
+        all_fields: true,
+        sort: 'package_count'
+      }
+      let response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(params),
+        headers: { 'Content-Type': 'application/json' }
+      })
+      if (response.status !== 200) {
+        throw response
+      }
+      response = await response.json()
+      // Convert CKAN group descriptor into "standard" collection descriptor
+      const organizations = response.result.map(org => {
+        return utils.convertToStandardCollection(org)
+      })
+      return organizations
+    } catch (e) {
+      console.warn('Error fetching organizations', e)
+      return []
     }
-    let response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(params),
-      headers: { 'Content-Type': 'application/json' }
-    })
-    if (response.status !== 200) {
-      throw response
-    }
-    response = await response.json()
-    // Convert CKAN group descriptor into "standard" collection descriptor
-    const organizations = response.result.map(org => {
-      return utils.convertToStandardCollection(org)
-    })
-    return organizations
   }
 
   async getProfile(owner) {
@@ -153,43 +168,53 @@ class DmsModel {
   }
 
   async getCollections(params) {
-    const action = 'group_list'
-    let url = new URL(resolve(this.api, action))
-    params = params ? params : {
-      all_fields: true
+    try {
+      const action = 'group_list'
+      let url = new URL(resolve(this.api, action))
+      params = params ? params : {
+        all_fields: true
+      }
+      let response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(params),
+        headers: { 'Content-Type': 'application/json' }
+      })
+      if (response.status !== 200) {
+        throw response
+      }
+      response = await response.json()
+      // Convert CKAN group descriptor into "standard" collection descriptor
+      const collections = response.result.map(collection => {
+        return utils.convertToStandardCollection(collection)
+      })
+      return collections
+    } catch (e) {
+      console.warn('Error fetching collections', e)
+      return []
     }
-    let response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(params),
-      headers: { 'Content-Type': 'application/json' }
-    })
-    if (response.status !== 200) {
-      throw response
-    }
-    response = await response.json()
-    // Convert CKAN group descriptor into "standard" collection descriptor
-    const collections = response.result.map(collection => {
-      return utils.convertToStandardCollection(collection)
-    })
-    return collections
   }
 
   async getCollection(collection) {
-    const action = 'group_show'
-    let url = new URL(resolve(this.api, action))
-    const params = {
-      id: collection
+    try {
+      const action = 'group_show'
+      let url = new URL(resolve(this.api, action))
+      const params = {
+        id: collection
+      }
+      let response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(params),
+        headers: { 'Content-Type': 'application/json' }
+      })
+      if (response.status !== 200) {
+        throw response
+      }
+      response = await response.json()
+      return utils.convertToStandardCollection(response.result)
+    } catch (e) {
+      console.warn('Error fetching collection', e)
+      return {}
     }
-    let response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(params),
-      headers: { 'Content-Type': 'application/json' }
-    })
-    if (response.status !== 200) {
-      throw response
-    }
-    response = await response.json()
-    return utils.convertToStandardCollection(response.result)
   }
 }
 

--- a/plugins/ckan_pages/cms.js
+++ b/plugins/ckan_pages/cms.js
@@ -1,54 +1,69 @@
-'use strict'
+"use strict"
 
-const config = require('../../config')
-const fetch = require('node-fetch')
+const config = require("../../config")
+const fetch = require("node-fetch")
 
 class CmsModel {
   constructor() {
-    this.api = config.get('CKAN_PAGES_URL')
+    this.api = config.get("CKAN_PAGES_URL")
   }
 
   // returns promise
   async getPost(slug) {
-   const url = `${this.api}ckanext_pages_show?page=${slug}`
-   const res = await fetch(url)
-   if (res.ok) {
-     const post = await res.json()
-     if (post.result) {
-       return post.result
-     } else {
-       throw {statusCode: 404}
-     }
-   } else {
-     const message = await res.text()
-     throw {statusCode: res.status, message}
-   }
+    try {
+      const url = `${this.api}ckanext_pages_show?page=${slug}`
+      const res = await fetch(url)
+      if (res.ok) {
+        const post = await res.json()
+        if (post.result) {
+          return post.result
+        } else {
+          throw { statusCode: 404 }
+        }
+      } else {
+        const message = await res.text()
+        throw { statusCode: res.status, message }
+      }
+    } catch (e) {
+      console.warn("Error geting ckan pages post", e)
+      return {}
+    }
   }
 
   // returns promise
   async getListOfPosts(size) {
-    const url = `${this.api}ckanext_pages_list?page_type=blog`
-    const res = await fetch(url)
-    if (res.ok) {
-      const posts = await res.json()
-      return posts.result
-    } else {
-      const message = await res.text()
-      throw {statusCode: res.status, message}
+    try {
+      const url = `${this.api}ckanext_pages_list?page_type=blog`
+      const res = await fetch(url)
+      if (res.ok) {
+        const posts = await res.json()
+        return posts.result
+      } else {
+        const message = await res.text()
+        throw { statusCode: res.status, message }
+      }
+    } catch (e) {
+      console.warn("Error geting ckan pages posts list", e)
+      return []
     }
   }
-  
+
   // returns promise
   async getListOfPages() {
-    const url = `${this.api}ckanext_pages_list?page_type=page`
-    const res = await fetch(url)
-    if (res.ok) {
-      const pages = await res.json()
-      return pages
-    } else {
-      /*istanbul ignore next*/
-      const message = await res.text()
-      throw {statusCode: res.status, message}
+    try {
+      const url = `${this.api}ckanext_pages_list?page_type=page`
+      const res = await fetch(url)
+      if (res.ok) {
+        const pages = await res.json()
+        return pages
+      } else {
+        /*istanbul ignore next*/
+        const message = await res.text()
+        throw { statusCode: res.status, message }
+      }
+    } catch (e) {
+      console.warn("Error geting ckan pages pages", e)
+      return {}
     }
   }
 }

--- a/plugins/ckan_pages/index.js
+++ b/plugins/ckan_pages/index.js
@@ -12,7 +12,14 @@ module.exports = function (app) {
   app.get('/', async (req, res, next) => {
     // Get latest 3 blog posts and pass it to home template
     const size = 3
-    let posts = await Model.getListOfPosts(size)
+    let posts = []
+    
+    try {
+      posts = await Model.getListOfPosts(size)
+    } catch (e) {
+      console.warn(e)
+    }
+
     posts = posts.map(post => {
       return {
         slug: post.name,
@@ -35,7 +42,14 @@ module.exports = function (app) {
   async function listStaticPages(req, res) {
     // Get latest 10 blog posts
     const size = 10
-    let posts = await Model.getListOfPosts(size)
+    let posts = []
+    
+    try {
+      posts = await Model.getListOfPosts(size)
+    } catch (e) {
+      console.warn(e)
+    }
+    
     posts = posts.map(post => {
       return {
         slug: post.name,

--- a/plugins/wp/cms.js
+++ b/plugins/wp/cms.js
@@ -43,27 +43,52 @@ class CmsModel {
   }
 
   async getListOfPages(query={}) {
-    query.type = "page"
-    const result = await this.getListOfPostsWithMeta(query)
-    return result.posts
+    try {
+      query.type = "page"
+      const result = await this.getListOfPostsWithMeta(query)
+      return result.posts
+    } catch (e) {
+      console.warn('Failed to fetch wordpress pages', e)
+      return []
+    }
   }
 
   async getListOfPosts(query) {
-    const result = await this.getListOfPostsWithMeta(query)
-    return result.posts
+    try {
+      const result = await this.getListOfPostsWithMeta(query)
+      return result.posts
+    } catch (e) {
+      console.warn('Failed to fetch wordpress posts', e)
+      return []
+    }
   }
 
 
   async getListOfPostsWithMeta(query) {
-    return await this.blog.postsList(query)
+    try {
+      return await this.blog.postsList(query)
+    } catch (e) {
+      console.warn('Failed to fetch wordpress list of posts with meta', e)
+      return []
+    }
   }
 
   async getCategories() {
-    return await this.blog.categoriesList()
+    try {
+      return await this.blog.categoriesList()
+    } catch (e) {
+      console.warn('Failed to fetch wordpress category list', e)
+      return []
+    }
   }
 
   async getSiteInfo() {
-    return await this.blog.get()
+    try {
+      return await this.blog.get()
+    } catch (e) {
+      console.warn('Failed to fetch wordpress site info', e)
+      return
+    }
   }
 
   api() {


### PR DESCRIPTION
I know this PR is hard to read because of so many whitespace changes (indent level is changed for all try/catch blocks.)

The only changes, however, are to wrap all `await` invocations in try/catch and to, where possible, return empty results to avoid crashing based on missing resources, etc.

I believe this is best practice when using `async` `await` and greatly eases debugging when the app crashes because of a malformed request body, or some other request failure which is heretofore swallowed whole by node.