### PR TITLE
Table schema field name missing fixed on custom dictionary. 

### DIFF
--- a/tests/utils/index.test.js
+++ b/tests/utils/index.test.js
@@ -214,7 +214,7 @@ test('datastore data dictionary => tableschema', t => {
   t.deepEqual(result, expected)
 
   result = utils.dataStoreDataDictionaryToTableSchema({
-    id: 'column',
+    id: 'Column',
     type: 'text',
     info: {
       title: 'Column',
@@ -224,7 +224,7 @@ test('datastore data dictionary => tableschema', t => {
   })
 
   expected = {
-    name: 'column',
+    name: 'Column',
     type: 'string',
     title: 'Column',
     constraints: {

--- a/utils/index.js
+++ b/utils/index.js
@@ -211,6 +211,7 @@ module.exports.dataStoreDataDictionaryToTableSchema = (dataDictionary) => {
     type: dataDictionaryType2TableSchemaType[dataDictionary.type] || 'any'
   }
   if (dataDictionary.info) {
+    field.name = dataDictionary.info.title || dataDictionary.id
     const constraintsAttributes = ['required', 'unique', 'minLength', 'maxLength', 'minimum', 'maximum', 'pattern', 'enum']
     field.constraints = {}
     Object.keys(dataDictionary.info).forEach(key => {


### PR DESCRIPTION
- Missing name field fixed when we use custom data dictionary. 