### PR TITLE
[fix][s] Configure Moment locale based on i18n

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ module.exports.makeApp = function () {
   const translationsDir = config.get('TRANSLATIONS') || '/i18n'
   i18n.configure({
     cookie: 'defaultLocale',
-    directory: __dirname + translationsDir
+    directory: __dirname + translationsDir,
+    defaultLocale: config.get('DEFAULT_LOCALE') || 'en'
   })
 
   // Middlewares
@@ -59,6 +60,13 @@ module.exports.makeApp = function () {
       maxAge: config.get("SESSION_COOKIE_MAX_AGE")
     }
   }))
+
+  // Configure Moment locale 
+  app.use(function (req, res, next) {
+    moment.locale(i18n.getLocale(req))
+
+    next()
+  });
   
   // enable flash messages
   app.use(flash())


### PR DESCRIPTION
@anuveyatsu 
Please, would you review this PR.

This fixes configuring of Moment locale.

**Description**
Moment locale was not changing according to `defaultLocale` cookie value. Idea was to set Moment locale in `frontend-v2` itself, not from Theme, so this can be reused in all cases that needs translations. In this particular case we use `moment.fromNow()` function which returns human readable value from `datetime` value. Our starting point was:

```javascript
i18n.configure({
  cookie: 'defaultLocale',
  directory: __dirname + translationsDir,
  locales: config.get('LOCALES') || ['en'],
  defaultLocale: config.get('DEFAULT_LOCALE') || 'en'
})

// also set it up for moment:
moment.locale(i18n.getLocale())
```

**Implementation**
1. In this solution I didn't use `locales: config.get('LOCALES') || ['en'],`, because `i18n` by default reads `/i18n` folder's translations files, so it overrides previous setting in `i18n.configure`.

2. Function `getLocale()` always returns `en` locale, no matter what `defaultLocale` value is. So I decided to use express middleware to obtain locale value for Moment:

```javascript
app.use(function (req, res, next) {
    moment.locale(i18n.getLocale(req))

    next()
  });
```

**Conclusion**
This solution is tested in Montreal theme and works as we expected. One more important thing is that this do not change implementation of `i18n`, so there is no need to change documentation.

