### PR TITLE
getOrganizations additional params support

### DIFF
--- a/lib/dms.js
+++ b/lib/dms.js
@@ -99,12 +99,15 @@ class DmsModel {
     }
   }
 
-  async getOrganizations() {
+  async getOrganizations(query = {}) {
     const action = 'organization_list'
-    const params = {
-      all_fields: true,
-      sort: 'package_count'
-    }
+    const params = Object.assign(
+      {
+         all_fields: true,
+         sort: 'package_count'
+      },
+      query
+    )
     const response = await this.getJsonResponse(params, action)
     // Convert CKAN group descriptor into "standard" collection descriptor
     const organizations = response.result.map(org => {

--- a/tests/lib/index.test.js
+++ b/tests/lib/index.test.js
@@ -136,7 +136,8 @@ test('getCollection api works', async t => {
     summary: 'A collection of economic indicators available on DataHub.',
     image: 'https://datahub.io/static/img/awesome-data/economic-data.png',
     count: 2,
-    extras: []
+    extras: [],
+    groups: []
   }
 
   t.deepEqual(result, expected)

--- a/utils/index.js
+++ b/utils/index.js
@@ -235,10 +235,11 @@ module.exports.convertToStandardCollection = (descriptor) => {
 
   standard.name = descriptor.name
   standard.title = descriptor.title || descriptor.display_name
-  standard.summary = descriptor.description ? descriptor.description.substring(0, 100) : ''
+  standard.summary = descriptor.description || ''
   standard.image = descriptor.image_display_url || descriptor.image_url
   standard.count = descriptor.package_count || 0
   standard.extras = descriptor.extras || []
+  standard.groups = descriptor.groups || []
 
   return standard
 }


### PR DESCRIPTION
-  Now `getOrganizations` DMS  supports users passed params such as .  `include_groups`,  `include_tags` etc..
- Default truncating description of organization removed from dms . It can be implemented on a theme. 