### PR TITLE
[search][s]: fixes dms search fq param

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -269,6 +269,10 @@ module.exports.convertToCkanSearchQuery = (query) => {
     ckanQuery.q = ckanQuery.q.trim()
   }
 
+  if (query.fq) {
+    ckanQuery.fq = ckanQuery.fq ? ckanQuery.fq + ' ' + query.fq : query.fq
+  }
+
   // standard 'size' => ckan 'rows'
   ckanQuery.rows = query.size || ''
 


### PR DESCRIPTION
In case a query has `fq` param don't forget to include it.