### PR TITLE
[env][xs]: fixes property 'replace' of undefined site url error

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -18,7 +18,9 @@ nconf.defaults({
     port: process.env.PORT || 4000
   },
   API_URL: api_url,
-  SITE_URL: process.env.SITE_URL.replace(/\/+$/, '') || 'http://0.0.0.0:4000',
+  SITE_URL: process.env.SITE_URL ?
+    process.env.SITE_URL.replace(/\/+$/, '')
+    : 'http://0.0.0.0:4000',
   SITE_LOCALE: process.env.SITE_LOCALE || 'en',
   WP_URL: process.env.WP_URL || 'http://127.0.0.1:6000',
   WP_BLOG_PATH: process.env.WP_BLOG_PATH || '/news',


### PR DESCRIPTION
When trying to launch app without `SITE_URL` set up (worked previously) there is an error:

```
 Cannot read property 'replace' of undefined
    at Object.<anonymous> (/Users/evgeniyavakarina/Documents/upwork/datopian/frontend-v2/config/index.js:21:34)

```

This PR is a fix for it