### PR TITLE
[fix][xs] Fix text view case without redirection

### DIFF
--- a/routes/dms.js
+++ b/routes/dms.js
@@ -202,23 +202,25 @@ module.exports = function () {
   function fetchTextContent(url) {
     return new Promise((resolve, reject) => {
       https.get(url, (res, error) => {
+        // Check if there is redirection and set new URL if yes
         if (res.statusCode === 301 || res.statusCode === 302) {
-          https.get(res.headers.location, (res, error) => {
-            let buff = new Buffer(0)
-            res.on('data', (chunk) => {
-              buff = Buffer.concat([buff, chunk])
-              if (buff.length > 10240) {
-                res.destroy()
-                resolve(buff.toString())
-              }
-            })
-            res.on('end', () => {
-              resolve(buff.toString())
-            } )
-          }).on('error', (e) => {
-            console.error(e)
-          })
+          url = res.headers.location
         }
+        https.get(url, (res, error) => {
+          let buff = new Buffer(0)
+          res.on('data', (chunk) => {
+            buff = Buffer.concat([buff, chunk])
+            if (buff.length > 10240) {
+              res.destroy()
+              resolve(buff.toString())
+            }
+          })
+          res.on('end', () => {
+            resolve(buff.toString())
+          })
+        }).on('error', (e) => {
+          console.error(e)
+        })
       }).on('error', (e) => {
         console.error(e)
       })


### PR DESCRIPTION
@anuveyatsu Please can you review this?

This solves https://gitlab.com/datopian/core/support/-/issues/250

There are cases when JSON/XML resources are external - linked ones. In those cases we don't need redirection. Example:
1. Dataset: https://donnees.montreal.ca/ville-de-montreal/contrats-et-subventions-api
2. External resource: http://ville.montreal.qc.ca/vuesurlescontrats/api/

With these changes we first check is there a redirection, and if yes we change the resource URL to `res.headers.location`. If there is not redirection the URL of the resource remains the same.