### PR TITLE
Robots txt added

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,12 @@ module.exports.makeApp = function () {
   // enable flash messages
   app.use(flash())
 
+  // Robots txt
+  app.use('/robots.txt', function (req, res, next) {
+    res.type('text/plain')
+    res.send("User-agent: *\nAllow: /");
+  });
+
   // Auth
   if (authEnabled) {
     authRoutes(app)


### PR DESCRIPTION
There was no  `/robots.txt`. When the crawler doesn't find `robots.txt` the next matched  `/:organization` route throws a 404 error.  So, adding `robots.txt ` as a middleware function. For now, it is allowing all paths.
