### PR TITLE
Include stack trace of an error if exists + small bug fix

### DIFF
--- a/routes/dms.js
+++ b/routes/dms.js
@@ -194,11 +194,13 @@ module.exports = function () {
     // Prep text views - load first 10Kb of a file to 'content' attribut which
     // we can render as is in the template.
     datapackage.displayResources = await Promise.all(datapackage.displayResources.map(async item => {
-      await Promise.all(item.resource.views.map(async (view, index) => {
-        if (view && view.specType === 'text' && item.resource.path) {
-          item.resource.views[index].content = await fetchTextContent(item.resource.path)
-        }
-      }))
+      if (item.resource.views) {
+        await Promise.all(item.resource.views.map(async (view, index) => {
+          if (view && view.specType === 'text' && item.resource.path) {
+            item.resource.views[index].content = await fetchTextContent(item.resource.path)
+          }
+        }))
+      }
       return item
     }))
 

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -2,13 +2,14 @@ const winston = require('winston')
 const config = require('../config/index')
 
 const customFormat = winston.format.printf((info) => {
-  const { level, message, ...meta } = info
-  return `${meta.timestamp} [${level}] ${message}`
+  const { level, message, stack, ...meta } = info
+  return `${meta.timestamp} [${level}] ${message}${stack ? '\n' + stack : ''}`
 })
 
 const logger = winston.createLogger({
   level: config.get('LOG_LEVEL') || 'info',
   format: winston.format.combine(
+    winston.format.errors({ stack: true }),
     winston.format.json(),
     winston.format.timestamp(),
     winston.format.colorize(),


### PR DESCRIPTION
The major issue with the current error logger is that it doesn't properly log full stack trace which is essential for debugging. This PR fixes it.

It also fixes a small bug when rendering a dataset page without `resource.views`.