### PR TITLE
Redirect to 404 page if resource don't exist. 

### DIFF
--- a/lib/dms.js
+++ b/lib/dms.js
@@ -68,6 +68,17 @@ class DmsModel {
     const datapackage = await this.getPackage(packageName, false)
     datapackage.resources = datapackage.resources.filter(item => item.name === resourceName)
 
+    // Redirect to 404 page if resource don't exist.
+    if (datapackage.resources.length == 0) {
+      var err = new Error();
+      err.status = 404;
+      err.statusText = 'RESOURCE NOT FOUND'
+      err.text = () => {
+        return 'Resource not found.'
+      }
+      throw (err)
+    }
+
     datapackage.resources = await Promise.all(datapackage.resources.map(async resource => {
       return {
         views: await this.getResourceViews(resource.id), // Fetch views for the resources


### PR DESCRIPTION
Before when the resource URL is invalid it just displays the blank content instead of displaying 404. Now it is fixed this PR.
