### PR TITLE
error message improved , page not found instead of url not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,9 +117,9 @@ module.exports.makeApp = function () {
   app.get('*', function (req, res, next) {
     let err = new Error()
     err.status = 404
-    err.statusText = 'REQUEST URL NOT FOUND'
+    err.statusText = 'PAGE NOT FOUND'
     err.text = () => {
-      return 'REQUEST URL NOT FOUND'
+      return 'PAGE NOT FOUND'
     }
     next(err)
   })

--- a/routes/dms.js
+++ b/routes/dms.js
@@ -269,7 +269,7 @@ module.exports = function () {
     // if not a valid profile, send them on the way
     if (!profile.created) {
       return res.status(404).render('404.html', {
-        message: `Page found: ${owner}`,
+        message: `PAGE NOT FOUND: ${owner}`,
         status: 404
       })
     }


### PR DESCRIPTION
I think ` PAGE NOT FOUND` is more relevant than the `requested URL  not found`.