### PR TITLE
Custom header added to differentiate frontend API request.

### DIFF
--- a/lib/dms.js
+++ b/lib/dms.js
@@ -17,7 +17,10 @@ class DmsModel {
     let query = querystring.stringify(params)
 
     let url = new URL(resolve(this.api, action + '?' + query))
-    let response = await fetch(url)
+    let response = await fetch(url, { 
+      headers: { 'INTERNAL_CALL': 'frontend' }
+    })
+    
     if (response.status !== 200) {
       throw response
     }


### PR DESCRIPTION
In some projects, we need to differentiate frontend API requests on the admin site so, for that adding a custom header.