### PR TITLE
wip: Env variable added for internal API url

### DIFF
--- a/env.template
+++ b/env.template
@@ -3,6 +3,9 @@ NODE_ENV=
 THEME=
 TRANSLATIONS=
 API_URL=http://127.0.0.1:5000/api/3/action/
+INTERNAL_API_URL=
+
+# Configure wordpress 
 WP_URL=http://127.0.0.1:6000
 WP_BLOG_PATH=
 WP_TOKEN=

--- a/lib/dms.js
+++ b/lib/dms.js
@@ -9,7 +9,7 @@ const logger = require('../utils/logger')
 class DmsModel {
   constructor(config) {
     this.config = config
-    this.api = config.get('API_URL')
+    this.api = config.get('INTERNAL_API_URL') ? config.get('INTERNAL_API_URL') : config.get('API_URL')
   }
 
   async getJsonResponse(params, action) {


### PR DESCRIPTION
Use internal API `INTERNAL_API_URL` if the ckan is running on the private network.  **Note that** you also need to provide public Url  `API_URL`  since it has been used on data explorer. 