### PR TITLE
Markdown error fixed when input data are not string eg. null or numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ module.exports.makeApp = function () {
 
   env.addFilter('processMarkdown', (str) => {
     try {
-      return processMarkdown.render(str)
+      return processMarkdown.render(String(str))
     } catch (e) {
       logger.warn('Failed to format markdown', e)
       return str

--- a/routes/dms.js
+++ b/routes/dms.js
@@ -165,7 +165,7 @@ module.exports = function () {
       owner: {
         name: profile.name,
         title: profile.title,
-        description: utils.processMarkdown.render(profile.description),
+        description: utils.processMarkdown.render(profile.description || ''),
         avatar: profile.image_display_url || profile.image_url
       },
       thisPageFullUrl: '//' + req.get('host') + req.originalUrl,
@@ -309,7 +309,7 @@ module.exports = function () {
       owner: {
         name: profile.name,
         title: profile.title,
-        description: utils.processMarkdown.render(profile.description),
+        description: utils.processMarkdown.render(profile.description || ''),
         avatar: profile.image_display_url || profile.image_url,
         joinDate: joinMonth + ' ' + joinYear,
       },

--- a/utils/index.js
+++ b/utils/index.js
@@ -486,12 +486,12 @@ module.exports.processDataPackage = function (datapackage) {
   const newDatapackage = JSON.parse(JSON.stringify(datapackage))
   if (newDatapackage.description) {
     newDatapackage.descriptionHtml = module.exports.processMarkdown
-      .render(newDatapackage.description)
+      .render(newDatapackage.description || '')
   }
 
   if (newDatapackage.readme) {
     newDatapackage.readmeHtml = module.exports.processMarkdown
-      .render(newDatapackage.readme)
+      .render(newDatapackage.readme || '')
   }
 
   newDatapackage.formats = newDatapackage.formats || []
@@ -499,7 +499,7 @@ module.exports.processDataPackage = function (datapackage) {
   newDatapackage.resources.forEach(resource => {
     if (resource.description) {
       resource.descriptionHtml = module.exports.processMarkdown
-        .render(resource.description)
+        .render(resource.description || '')
     }
     // Normalize format (lowercase)
     if (resource.format) {


### PR DESCRIPTION
 The below errors are frequently occurring so raising PR for a fix. 
```
2021-10-27T12:15:02.023Z [warn] Failed to format markdown Input data should be a String
Error: Input data should be a String
    at MarkdownIt.parse (/usr/src/app/node_modules/markdown-it/lib/index.js:518:11)
    at MarkdownIt.render (/usr/src/app/node_modules/markdown-it/lib/index.js:543:36)
    at Context.<anonymous> (/usr/src/app/index.js:238:30)
    at b_content (eval at _compile (/usr/src/app/node_modules/nunjucks/src/environment.js:637:18), <anonymous>:54:102)
    at eval (eval at _compile (/usr/src/app/node_modules/nunjucks/src/environment.js:637:18), <anonymous>:129:86)
    at b_message (eval at _compile (/usr/src/app/node_modules/nunjucks/src/environment.js:637:18), <anonymous>:218:1)
    at eval (eval at _compile (/usr/src/app/node_modules/nunjucks/src/environment.js:637:18), <anonymous>:35:86)
    at b_bodyclass (eval at _compile (/usr/src/app/node_modules/nunjucks/src/environment.js:637:18), <anonymous>:39:1)
    at eval (eval at _compile (/usr/src/app/node_modules/nunjucks/src/environment.js:637:18), <anonymous>:24:88)
    at b_styles (eval at _compile (/usr/src/app/node_modules/nunjucks/src/environment.js:637:18), <anonymous>:185:1)
```