### PR TITLE
Connect to CKAN API via private network from frontend server.

### DIFF
--- a/lib/dms.js
+++ b/lib/dms.js
@@ -9,7 +9,7 @@ const logger = require('../utils/logger')
 class DmsModel {
   constructor(config) {
     this.config = config
-    this.api = config.get('API_URL')
+    this.api = config.get('INTERNAL_API_URL') || config.get('API_URL')
   }
 
   async getJsonResponse(params, action) {


### PR DESCRIPTION
DMS module runs in Nodejs (backend) and makes lots of requests to CKAN API using public URL which means all those requests are going through NGINX. In some situations it is being blocked depending on proxy configs, e.g., there might be limit on number of concurrent connections from a given IP or number of connections per second.

To improve this, we want to make requests from node app to CKAN API within the private network.

There are other places where frontend does connect to CKAN API (e.g., in custom themes developers don't always use this DMS library but they write custom code). But this DMS module makes 90% of requests, it also does a lot of concurrent requests where a package has lots of resources.