### PR TITLE
Handled error with try catch on homepage wordpress content

### DIFF
--- a/plugins/wp/index.js
+++ b/plugins/wp/index.js
@@ -6,6 +6,7 @@ const i18n = require('i18n')
 const cms = require('./cms')
 const config = require('../../config')
 const utils = require('../../utils')
+const logger = require('../../utils/logger')
 
 
 module.exports = function (app) {
@@ -21,29 +22,33 @@ module.exports = function (app) {
 
   app.get('/', async (req, res,next) => {
     // Get latest 3 blog posts and pass it to home template
-    let posts = await Model.getListOfPosts({
-      number: 3,
-      fields: 'slug,title,content,date,modified,featured_image,categories,attachments'
-    })
-    posts = posts.map(post => {
-      const postAttachments = post.attachments ? Object.values(post.attachments) : []
-      const featuredImageAttachment = Object
-        .values(postAttachments)
-        .find(attachment => attachment.URL === post.featured_image) || {}
-
-      return {
-        slug: post.slug,
-        title: post.title,
-        content: post.content,
-        published: moment(post.date).format('Do MMMM YYYY'),
-        modified: moment(post.modified).format('Do MMMM YYYY'),
-        image: post.featured_image,
-        categories: post.categories ? Object.keys(post.categories) : [],
-        imageCaption: featuredImageAttachment.caption,
-        imageAlt: featuredImageAttachment.alt
-      }
-    })
-    res.locals.posts = posts
+    try {
+      let posts = await Model.getListOfPosts({
+        number: 3,
+        fields: 'slug,title,content,date,modified,featured_image,categories,attachments'
+      })
+      posts = posts.map(post => {
+        const postAttachments = post.attachments ? Object.values(post.attachments) : []
+        const featuredImageAttachment = Object
+          .values(postAttachments)
+          .find(attachment => attachment.URL === post.featured_image) || {}
+  
+        return {
+          slug: post.slug,
+          title: post.title,
+          content: post.content,
+          published: moment(post.date).format('Do MMMM YYYY'),
+          modified: moment(post.modified).format('Do MMMM YYYY'),
+          image: post.featured_image,
+          categories: post.categories ? Object.keys(post.categories) : [],
+          imageCaption: featuredImageAttachment.caption,
+          imageAlt: featuredImageAttachment.alt
+        }
+      })
+      res.locals.posts = posts
+    } catch (err) {
+      logger.error(`Failed to get homepage content from wordpress. ${err}`)
+    }
     next()
   })
 


### PR DESCRIPTION
Don't break a site when the frontend is unable to fetch WordPress home content.  
 
 Not related to this PR but  I can issue it always looking for post number 3 so, probably it was implemented for a specific project.  I think we should use slug name eg 'home' instead of post number but need to confirm if it is already used on other projects. 