### PR TITLE
CI/CD: run tests using node v14 and v16 as well.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This enables us to deploy the frontend service using the latest Node version.