### PR TITLE
add datatables_view to enable table views

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -142,7 +142,8 @@ module.exports.ckanViewToDataPackageView = (ckanView) => {
     pdf_view: 'document',
     image_view: 'web',
     webpage_view: 'web',
-    text_view: 'text'
+    text_view: 'text',
+    datatables_view: 'table',
   }
   const dataPackageView = JSON.parse(JSON.stringify(ckanView))
   dataPackageView.specType = viewTypeToSpecType[ckanView.view_type]


### PR DESCRIPTION
This pr fixes table preview issue.

also this need to added to the ckan deployment configuration

```
CKAN__PLUGINS=datatables_view .....

CKAN__DATASTORE__SQLSEARCH__ENABLED=true
```